### PR TITLE
Fix Issues with sending unnecessary data

### DIFF
--- a/src/Logger/Processor/InstallationType.php
+++ b/src/Logger/Processor/InstallationType.php
@@ -19,8 +19,8 @@ class InstallationType {
    *   The result.
    */
   public function __invoke(array|LogRecord $record) {
-    if(!is_array($record)) {
-      $record->toArray();
+    if ($record instanceof \Monolog\LogRecord) {
+      $record = $record->toArray();
     }
 
     // Remove any args from a possible backtrace:

--- a/src/Logger/Processor/InstallationType.php
+++ b/src/Logger/Processor/InstallationType.php
@@ -19,15 +19,16 @@ class InstallationType {
    *   The result.
    */
   public function __invoke(array|LogRecord $record) {
-    if ($record instanceof \Monolog\LogRecord) {
-      $record = $record->toArray();
+    // LogRecord doesn't have unset method.
+    // we can't use is_array because LogRecord consider an array in php.
+    if (!$record instanceof LogRecord) {
+      $this->removeBacktraceDetails($record);
     }
-
-    // Remove any args from a possible backtrace:
-    if (isset($record['context']['backtrace']) && is_array($record['context']['backtrace'])) {
-      foreach (array_keys($record['context']['backtrace']) as $ndx) {
-        unset($record['context']['backtrace'][$ndx]['args']);
-        unset($record['context']['backtrace'][$ndx]['object']);
+    else {
+      $record_array = $record->toArray();
+      if (isset($record_array['context'])) {
+        $this->removeBacktraceDetails($record_array);
+        $record = $record->with(context: $record_array['context']);
       }
     }
 
@@ -42,6 +43,22 @@ class InstallationType {
     }
 
     return $record;
+  }
+
+  /**
+   * Removes arguments and objects from the backtrace if present.
+   *
+   * @param array $record
+   *   The record array.
+   */
+  private function removeBacktraceDetails(array &$record)
+  {
+    if (isset($record['context']['backtrace']) && is_array($record['context']['backtrace'])) {
+      foreach (array_keys($record['context']['backtrace']) as $ndx) {
+        unset($record['context']['backtrace'][$ndx]['args']);
+        unset($record['context']['backtrace'][$ndx]['object']);
+      }
+    }
   }
 
 }


### PR DESCRIPTION
We had a problem with the `unset` function in the new Monolog version. It wasn't working with data with `LogRecord` type, causing 502 errors because the server couldn't handle all the data.